### PR TITLE
Remove "browser" from package.json to fix Browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "jam": {
     "main": "./dist/less.js"
   },
-  "browser": "./dist/less.js",
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
I tried to follow the discussion from https://github.com/less/less.js/pull/2525, but wasn't really understanding why this was added in the first place.

Using Browserify 11.1.0, it's impossible to use less @2.5.1 as part of your build. I can reproduce it as easily as:

``` bash
npm install less
echo "require('less')" > index.js
browserify index.js
```

You'll see the error:

```
Error: Cannot find module './utils' from '/private/tmp/fdlsjlkfsd/node_modules/less/dist'
    at /Users/nolan/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:55:21
    at load (/Users/nolan/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/nolan/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
    at /Users/nolan/.npm-packages/lib/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:82:15)
```

This commit fixes that.
